### PR TITLE
Openshift file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY CRS-logo-full_size-512x257.png /var/www/html/error/
 COPY docker-entrypoint.sh /
 
 RUN mkdir /var/log/apache2/audit /var/lock/apache2 \
-    && chown www-data:root -R /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf /var/run/ /var/log/apache2/ /etc/apache2/conf/httpd.conf /var/www/html/ \
-    && chmod g+w -R /etc/apache2/modsecurity.d/owasp-crs/crs-setup.conf /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/apache2/
+    && chgrp -R 0 /etc/apache2/modsecurity.d/ /var/run/ /var/log/ /etc/apache2/conf/httpd.conf /var/www/html/ \
+    && chmod -R g=u /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["apachectl", "-f", "/etc/apache2/conf/httpd.conf", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ COPY CRS-logo-full_size-512x257.png /var/www/html/error/
 COPY docker-entrypoint.sh /
 
 RUN mkdir /var/log/apache2/audit /var/lock/apache2 \
-    && chgrp -R 0 /etc/apache2/modsecurity.d/ /var/run/ /var/log/ /etc/apache2/conf/httpd.conf /var/www/html/ \
-    && chmod -R g=u /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/
+    && chgrp -R 0 /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/ \
+    && chmod -R g=u /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/ \
+    && chown www-data:root -R /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["apachectl", "-f", "/etc/apache2/conf/httpd.conf", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY CRS-logo-full_size-512x257.png /var/www/html/error/
 COPY docker-entrypoint.sh /
 
 RUN mkdir /var/log/apache2/audit /var/lock/apache2 \
-    && chgrp -R 0 /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/ \
     && chmod -R g=u /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/ \
     && chown www-data:root -R /etc/apache2/modsecurity.d/ /etc/apache2/conf/httpd.conf /var/lock/ /var/run/ /var/log/ /var/www/html/
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # modsecurity-crs-rp
 
-This Docker image inherits from the official OWASP Core Rule Set Docker image (ModSecurity + Core Rule Set) and adds some configurable variables and an Apache Reverse Proxy configuration. 
+This Docker image inherits from the official OWASP Core Rule Set Docker image (ModSecurity + Core Rule Set) and adds some configurable variables and an Apache Reverse Proxy configuration.
 
-The goal is to provide a fully functional CRS in a single command:  
+The goal is to provide a fully functional CRS in a single command:
+
 * This container can be placed in front of an application.
 * Many CRS variables can be set.
 * And it can additionally consider ModSecurity CRS tuning.
-  
-  
+
 ## Environment Variables
+
 * PARANOIA: paranoia_level
 * EXECUTING_PARANOIA: executing_paranoia_level
 * ENFORCE_BODYPROC_URLENCODED: enforce_bodyproc_urlencoded
@@ -27,24 +28,22 @@ The goal is to provide a fully functional CRS in a single command:
 * TOTAL_ARG_LENGTH: total_arg_length
 * MAX_FILE_SIZE: max_file_size
 * COMBINED_FILE_SIZES: combined_file_sizes
-  
-  
-See https://coreruleset.org/ for further information.
-  
+
+See <https://coreruleset.org/> for further information.
+
 * BACKEND: application backend
 * PORT: listening port of apache
   
 ## ModSecurity Tuning
-  
+
 There are two possible ways to pass ModSecurity tuning rules to the container:
 
 * To map the ModSecurity tuning file(s) via volumes into the container during the run command 
 * To copy the ModSecurity tuning file(s) into the created container and then start the container
-  
-  
-##### Map ModSecurity tuning file via volume
-  
-```
+
+### Map ModSecurity tuning file via volume
+
+```bash
 docker run -dti \
    --name apachecrsrp \
    -p 1.2.3.4:80:8001 \
@@ -52,13 +51,12 @@ docker run -dti \
    -v /path/to/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf:/etc/apache2/modsecurity.d/owasp-crs/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf \
    franbuehler/modsecurity-crs-rp:v3.1
 ```
-  
-  
-##### Copy ModSecurity tuning file into created container
-  
+
+### Copy ModSecurity tuning file into created container
+
 This example can be helpful when no volume mounts are possible (some CI pipelines).
-  
-```
+
+```bash
 docker create -ti --name apachecrsrp \
    -p 1.2.3.4:80:8001 \
    franbuehler/modsecurity-crs-rp:v3.1
@@ -68,15 +66,12 @@ docker cp /path/to/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf \
   
 docker start apachecrsrp
 ```
-  
-  
-  
+
 ## docker run examples
-  
-  
-##### Full example with all possible environment variables
-  
-```
+
+### Full example with all possible environment variables
+
+```bash
 docker run -dti --name apachecrsrp -p 0.0.0.0:80:8001 \
    -e PARANOIA=1 \
    -e EXECUTING_PARANOIA=2 \
@@ -100,25 +95,23 @@ docker run -dti --name apachecrsrp -p 0.0.0.0:80:8001 \
    -e PORT=8001 \
    franbuehler/modsecurity-crs-rp
 ```
-  
-  
-##### Example run command for CI integration when no port mapping is possible
-  
-```
+
+### Example run command for CI integration when no port mapping is possible
+
+```bash
 docker run -dt --name apachecrsrp \
    -e PARANOIA=1 \
    -e ANOMALYIN=5 \
    -e ANOMALYOUT=4 \
    -e BACKEND=http://172.17.0.1:8000 \
-   -e PORT=8001 
-   --expose 8001 
+   -e PORT=8001 \
+   --expose 8001 \
    franbuehler/modsecurity-crs-rp
 ```
-  
-  
-##### Just another example
-  
-```
+
+### Just another example
+
+```bash
 docker run -dti --name apachecrsrp \
    -p 1.2.3.4:80:8080 \
    -e PARANOIA=1 \
@@ -134,12 +127,9 @@ docker run -dti --name apachecrsrp \
    -e BACKEND=http://192.168.192.57:8000 \
    -e PORT=8080 franbuehler/modsecurity-crs-rp
 ```
-  
-    
+
 ## Example docker-compose.yaml
 
+### docker-compose.yaml for easier use
 
-##### docker-compose.yaml for easier use
-
-See: https://github.com/franbuehler/modsecurity-crs-rp/blob/v3.1/docker-compose.yaml
-  
+See: <https://github.com/franbuehler/modsecurity-crs-rp/blob/v3.1/docker-compose.yaml>


### PR DESCRIPTION
The command `apachectl -M` showed file permission errors.

Support Arbitrary User IDs permissions according to OpenShift [documentation](https://docs.okd.io/latest/creating_images/guidelines.html#openshift-specific-guidelines).

README.md markdown formatting and docker run command fix.